### PR TITLE
Backend for bit reversal

### DIFF
--- a/ocaml/backends/coq.ml
+++ b/ocaml/backends/coq.ml
@@ -228,6 +228,7 @@ and pp_prim_ubits1 ppf (f: Cuttlebone.Extr.PrimUntyped.ubits1) =
   let pp_app fmt = pp_app ppf fmt in
   match f with
   | UNot -> pp_raw "UNot"
+  | URev -> pp_raw "URev"
   | USExt width -> pp_app "USExt" "%d" width
   | UZExtL width -> pp_app "UZExtL" "%d" width
   | UZExtR width -> pp_app "UZExtR" "%d" width

--- a/ocaml/backends/dot.ml
+++ b/ocaml/backends/dot.ml
@@ -8,6 +8,7 @@ let bits1_name =
   let open Extr.PrimTyped in
   function
   | Not _sz -> "Not"
+  | Rev _ -> "Rev"
   | SExt (_, _) -> "SExt"
   | ZExtL (_sz, _width) -> "ZExtL"
   | ZExtR (_sz, _width) -> "ZExtR"

--- a/ocaml/backends/verilog.ml
+++ b/ocaml/backends/verilog.ml
@@ -227,6 +227,14 @@ let assignment_to_string' (gensym: int ref) (assignment: assignment) =
    | EUnop (fn, arg1) ->
       (match fn with
        | Not _ -> default_left ^ "~" ^ arg1
+       | Rev sz ->
+        let rec loop n = if n = 0
+          then Printf.sprintf "%s[%d]" arg1 n
+          else Printf.sprintf "%s[%d], " arg1 n ^ loop (n - 1) in
+        let rhs = if sz = 0 || sz = 1
+            then lhs
+            else "{" ^ loop (sz-1) ^ "}" in
+        default_left ^ rhs
        | Repeat (_, times) -> default_left ^ Printf.sprintf "{%d{%s}}" times arg1
        | Slice (_, offset, slice_sz) -> default_left ^ arg1 ^ "[" ^ (string_of_int offset) ^ " +: " ^ string_of_int slice_sz ^ "]"
        | SExt _ | ZExtL _ | ZExtR _ | Lowered _ -> failwith_unlowered ())

--- a/ocaml/cuttlebone/cuttlebone.ml
+++ b/ocaml/cuttlebone/cuttlebone.ml
@@ -295,6 +295,7 @@ module Util = struct
     let open Extr.PrimTyped in
     function
     | Not _ -> "not"
+    | Rev _ -> "rev"
     | SExt (_, _) -> "sext"
     | ZExtL (_, _) -> "zextl"
     | ZExtR (_, _) -> "zextr"

--- a/tests/dune.inc
+++ b/tests/dune.inc
@@ -249,6 +249,25 @@ Extraction \"register_file_bypassing.ml\" register_file_bypassing.prog.\n")))
   (deps (package koika) register_file_bypassing.ml)
   (action (run cuttlec %{deps} -T all -o .))))
 
+(subdir reverse.v.d
+ (rule
+  (action
+   (write-file reverse_extr.v
+     "Require Coq.extraction.Extraction tests.reverse.
+Extraction \"reverse.ml\" reverse.prog.\n")))
+
+ (coq.extraction
+  (prelude reverse_extr)
+  (extracted_modules reverse)
+  (theories Ltac2 Koika tests)
+  (flags "-w" "-overriding-logical-loadpath"))
+
+ (rule
+  (target reverse.v)
+  (alias runtest)
+  (deps (package koika) reverse.ml)
+  (action (run cuttlec %{deps} -T all -o .))))
+
 (subdir shadowing.lv.d
  (rule
   (target shadowing.v)

--- a/tests/reverse.v
+++ b/tests/reverse.v
@@ -1,0 +1,38 @@
+(*! Regression test for bit reversal !*)
+Require Import Koika.Frontend.
+
+Inductive reg_t := r1.
+
+Inductive rule_name_t := rl.
+
+Definition R (reg: reg_t) : type := bits_t 16.
+
+Definition r (reg: reg_t) : R reg := Bits.zero.
+
+Definition urule  : uaction reg_t empty_ext_fn_t := {{
+  write0(r1, >< read0(r1))
+}}.
+
+Definition rules (rl : rule_name_t) := tc_rule R empty_Sigma urule.
+
+Definition package := {|
+  ip_koika := {|
+    koika_reg_types := R;
+    koika_reg_init := r;
+    koika_ext_fn_types := empty_Sigma;
+    koika_rules := rules;
+    koika_rule_external := fun _ => false;
+    koika_scheduler := rl |> done;
+    koika_module_name := "reverse"
+  |};
+  ip_sim := {|
+    sp_ext_fn_specs := empty_ext_fn_props;
+    sp_prelude := None
+  |};
+  ip_verilog := {|
+    vp_ext_fn_specs := empty_ext_fn_props
+  |}
+|}.
+
+Definition prog := Interop.Backends.register package.
+Extraction "reverse.ml" prog.


### PR DESCRIPTION
This PR adds a verilog backend for bit reversal

The following koika:

```
Definition urule  : uaction reg_t empty_ext_fn_t := {{
  write0(r1, >< read0(r1))
}}.
```

can now generate this verilog:

```
// -*- mode: verilog -*-
// Generated by cuttlec from a Kôika module
module reverse(input wire[0:0] CLK, input wire[0:0] RST_N);
	reg[15:0] r1 /* verilator public */ = 16'b0;


	always @(posedge CLK) begin
		if (!RST_N) begin
			r1 <= 16'b0;
		end else begin
			r1 <= {r1[15], r1[14], r1[13], r1[12], r1[11], r1[10], r1[9], r1[8], r1[7], r1[6], r1[5], r1[4], r1[3], r1[2], r1[1], r1[0]};
		end
	end
endmodule
```